### PR TITLE
skip_before_filter becomes skip_before_action to work with redmine 4.1.1

### DIFF
--- a/app/controllers/github_commits_controller.rb
+++ b/app/controllers/github_commits_controller.rb
@@ -2,8 +2,8 @@ class GithubCommitsController < ApplicationController
   
   unloadable
    
-  skip_before_filter :check_if_login_required
-  skip_before_filter :verify_authenticity_token
+  skip_before_action :check_if_login_required
+  skip_before_action :verify_authenticity_token
   
   before_action :verify_signature?
   


### PR DESCRIPTION
Hi BoTreeConsultingTeam

Regarding your tool i had issues getting it to work on our redmine 4.1.1 stable instance and following the recommendation of koppen in this reply : https://github.com/koppen/redmine_github_hook/issues/87#issuecomment-332433468

I tried changing the function from skip_before_filter to skip_before_action and now the plugin  is working correctly. Before with the filter function redmine would simply fail to start.

I hope this little correction can help a lot of folks in the long run.

Thank you for your time.
JPBD