### PR TITLE
New feature in same plugin we did code in house and want to share

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ This plugin adds a comment in redmine issue whenever user commits to github with
 5. For repository, webhook should be created with payload-url as `localhost:3000/github_commits/create_comment.json` where in url replace `localhost:3000` with your host address.
 
 6. In Redmine, Go to Administration -> Settings -> General Tab and change text formatting to `Markdown`. This will show the comment message properly.
+
+## Steps to use second feature (github change notification) which moves issues when there is a PR
+
+1. Create webhook like previous feature but with `/github_commits/github_change_notification.json` as URL. Send Pull Request only.
+
+2. Set ENV Variables like when you did for `GITHUB_SECRET_TOKEN` but for `CURRENT_REDMINE_STATE` (single integer) and `NEXT_REDMINE_STATE` (single integer).
+
+3. When doing a PR add `#rmXXX` like previous in the title to point which redmine ticket number must be automatically updated.

--- a/app/controllers/github_commits_controller.rb
+++ b/app/controllers/github_commits_controller.rb
@@ -2,8 +2,8 @@ class GithubCommitsController < ApplicationController
   
   unloadable
    
-  skip_before_filter :check_if_login_required
-  skip_before_filter :verify_authenticity_token
+  skip_before_action :check_if_login_required
+  skip_before_action :verify_authenticity_token
   
   before_action :verify_signature?
   

--- a/app/controllers/github_commits_controller.rb
+++ b/app/controllers/github_commits_controller.rb
@@ -22,7 +22,7 @@ class GithubCommitsController < ApplicationController
       issue = Issue.find_by(id: issue_id)
       #use env var if defined, else fails
       if ENV["CURRENT_REDMINE_STATE"].nil? or ENV["NEXT_REDMINE_STATE"].nil?
-        Rails.logger.info "Environment variable wrong. Will not do anything."
+        Rails.logger.info "Environment variables are wrong. Will not do anything."
         resp_json = {success: false, error: t('lables.env_var_missing') }
       else
         #if issue id exists in redmine & status is matching currentstate integer (status code)

--- a/app/controllers/github_commits_controller.rb
+++ b/app/controllers/github_commits_controller.rb
@@ -22,8 +22,7 @@ class GithubCommitsController < ApplicationController
       issue = Issue.find_by(id: issue_id)
       #use env var if defined, else fails
       if ENV["CURRENT_REDMINE_STATE"].nil? or ENV["NEXT_REDMINE_STATE"].nil?
-        Rails.logger.info "Environment variable missing. Will not do anything."
-        Rails.logger.info "You must set an integer value for Both env var CURRENT_REDMINE_STATE and NEXT_REDMINE_STATE."
+        Rails.logger.info "Environment variable wrong. Will not do anything."
         resp_json = {success: false, error: t('lables.env_var_missing') }
       else
         #if issue id exists in redmine & status is matching currentstate integer (status code)
@@ -31,7 +30,7 @@ class GithubCommitsController < ApplicationController
           issue.update(status_id: ENV["NEXT_REDMINE_STATE"].to_i)
           resp_json = {success: true}
         else
-          Rails.logger.info "Could not update issue " + issue_id.to_s + " with given ENV vars. Is the issue number correct and are ENV var both integers?"
+          Rails.logger.info "Could not update issue " + issue_id.to_s + "."
           resp_json = {success: false, error: t('lables.no_update') }
         end
 

--- a/app/controllers/github_commits_controller.rb
+++ b/app/controllers/github_commits_controller.rb
@@ -15,16 +15,18 @@ class GithubCommitsController < ApplicationController
   def github_change_notification
     resp_json = nil
     # if payload contains pr and action is opened (new pr)
-    if params[:pull_request].present? && params[:action] == "opened"
-      
+    if params[:pull_request].present? && params[:pull_request][:state] == "open"
       #get issue ID
       pr_title = params[:pull_request][:title]
       issue_id = pr_title.partition(REDMINE_ISSUE_NUMBER_PREFIX).last.split(" ").first.to_i
       issue = Issue.find_by(id: issue_id)
-      
       #if issue id exists in redmine & status is in progress (2)
       if issue.present? && issue.status_id == 2
-        issue.status = 14 #jenkins validation
+        #we are using status id 14 for "jenkins validation" which we created.
+        #you can easily adapt this plugin to your need by changing 
+        #the "from" status id in the previous if conditional statement and 
+        #the "to" status id in next line update statement
+        issue.update(status_id: 14) #jenkins validation
         resp_json = {success: true}
       else
         resp_json = {success: false, error: t('lables.no_pr_found') }
@@ -40,8 +42,6 @@ class GithubCommitsController < ApplicationController
     end
 
   end
-  # --
-
 
   def create_comment
     resp_json = nil

--- a/app/controllers/github_commits_controller.rb
+++ b/app/controllers/github_commits_controller.rb
@@ -20,13 +20,18 @@ class GithubCommitsController < ApplicationController
       pr_title = params[:pull_request][:title]
       issue_id = pr_title.partition(REDMINE_ISSUE_NUMBER_PREFIX).last.split(" ").first.to_i
       issue = Issue.find_by(id: issue_id)
+      #use env var if defined, else use default
+      currentstate = ENV["CURRENT_REDMINE_STATE"]
+      if currentstate.nil?
+        currentstate = 2 #default for in progress
+      end
+      nextstate = ENV["NEXT_REDMINE_STATE"]
+      if nextstate.nil?
+        nextstate = 3 #default for in review
+      end
       #if issue id exists in redmine & status is in progress (2)
-      if issue.present? && issue.status_id == 2
-        #we are using status id 14 for "jenkins validation" which we created.
-        #you can easily adapt this plugin to your need by changing 
-        #the "from" status id in the previous if conditional statement and 
-        #the "to" status id in next line update statement
-        issue.update(status_id: 14) #jenkins validation
+      if issue.present? && issue.status_id == currentstate.to_i
+        issue.update(status_id: nextstate.to_i)
         resp_json = {success: true}
       else
         resp_json = {success: false, error: t('lables.no_pr_found') }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,5 +3,7 @@ en:
   lables:
     no_commit_data_found: "Request does not have commit data."
     no_issue_found: "Issue not found."
+    no_pr_found: "Request does not have PR data."
+    no_update: "status was not updated for missing requirements."
   commit:
     message: ! "__Github Commit__ - __%{author}__ has commited on __%{branch}__ branch with message: __%{message}__ , [%{commit_id}](%{commit_url})"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,5 +5,6 @@ en:
     no_issue_found: "Issue not found."
     no_pr_found: "Request does not have PR data."
     no_update: "status was not updated for missing requirements."
+    env_var_missing: "Environment variable missing. Will not do anything."
   commit:
     message: ! "__Github Commit__ - __%{author}__ has commited on __%{branch}__ branch with message: __%{message}__ , [%{commit_id}](%{commit_url})"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 # Plugin's routes
 # See: http://guides.rubyonrails.org/routing.html
 post 'github_commits/create_comment.json', to: 'github_commits#create_comment'
+post 'github_commits/github_change_notification.json', to: 'github_commits#github_change_notification'

--- a/test1
+++ b/test1
@@ -1,1 +1,0 @@
-initial commit test file

--- a/test1
+++ b/test1
@@ -1,0 +1,1 @@
+initial commit test file


### PR DESCRIPTION
Hi BoTreeConsultingTeam i hope you are doing well.

Starting from your work we developed a new feature to add in this plugin. Maybe some other user will see this plugin and eventually want to use the feature.

It's pretty bare-bone, but this feature allows for tickets to be automatically updated when receiving a PR webhook from github.

You can setup the same webhook as you did but change the payload URL to "github_change_notification" instead of "create_comment". It uses the same github_secret_token, so on github paste the same token. It also uses the same `- #rmXXX` scheme you are using for commits message, **but it must be included in the PR title.**

To use the feature now, setup the following two environment variables : 

CURRENT_REDMINE_STATE
NEXT_REDMINE_STATE

Before starting Redmine (the same as setting up the Github Token variable). To get the status numbers, in redmine administration, hover over the status and the link target will contain the status number ID.

**If none are set, the default CURRENT will be 2 (In Progress) and the default NEXT will be 3 (In Review).**

This work has been done during my employment at FJNR ([Web site](https://fjnr.ca/) - [Github](https://github.com/FJNR-inc)) with the participation of [Noel Rignon](https://github.com/RignonNoel) regarding the research and analysis of your plugin, with the goal of having automations on our internal task management processes.

